### PR TITLE
Fix false error

### DIFF
--- a/arcaflow_plugin_horreum_client/horreum_client_plugin.py
+++ b/arcaflow_plugin_horreum_client/horreum_client_plugin.py
@@ -4,6 +4,7 @@ import sys
 import typing
 import requests
 
+import warnings
 from arcaflow_plugin_sdk import plugin
 from horreum_client_schema import InputParams, SuccessOutput, ErrorOutput
 
@@ -17,6 +18,10 @@ from horreum_client_schema import InputParams, SuccessOutput, ErrorOutput
 def horreum_client(
     params: InputParams,
 ) -> typing.Tuple[str, typing.Union[SuccessOutput, ErrorOutput]]:
+
+    # Conditionally suppress SSL warnings only if TLS verification is disabled
+    if not params.tls_verify:
+        warnings.filterwarnings("ignore", message="Unverified HTTPS request")
 
     send_url = (
         f"{params.horreum_url}/api/run/data?"

--- a/arcaflow_plugin_horreum_client/horreum_client_plugin.py
+++ b/arcaflow_plugin_horreum_client/horreum_client_plugin.py
@@ -56,7 +56,7 @@ def horreum_client(
     except requests.HTTPError as e:
         return "error", ErrorOutput(f"Error returned from the Horreum server: {e}")
 
-    if int(send_return.status_code) != 200 or not send_return.text.isdigit():
+    if not send_return.ok or not send_return.text.isdigit():
         return "error", ErrorOutput(f"Failed to upload object: {send_return.text}")
 
     print("==> Upload complete")


### PR DESCRIPTION
## Changes introduced with this PR

- Horreum responds with a 202 when it successfully uploads an object which gets flagged as an error since the code is looking only for 200. I have it now accept anything in the 200 range.
- Also suppress the SSL warning when SSL check is disabled.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).